### PR TITLE
Add base Home Assistant add-on structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+ARG BUILD_FROM=ghcr.io/home-assistant/${BUILD_ARCH}-base:2025.8.0
+# hadolint ignore=DL3006
+FROM ${BUILD_FROM}
+
+# Install Python for the polling script
+# hadolint ignore=DL3018
+RUN apk add --no-cache python3 py3-pip
+
+# Copy run script
+COPY run.sh /run.sh
+RUN chmod +x /run.sh
+
+WORKDIR /app
+
+CMD [ "/run.sh" ]

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,34 @@
+---
+name: Vevor EML3500 RS232 Wi-Fi bridge
+version: "0.1.0"
+slug: vevor_eml3500_rs232_wifi
+description: Polls Vevor EML3500 via RS232/WiFi bridge and publishes to MQTT.
+arch:
+  - amd64
+  - armv7
+  - armhf
+  - aarch64
+  - i386
+startup: application
+boot: auto
+init: false
+homeassistant: "2025.8.0"
+ports: {}
+options:
+  bridge_host: 192.168.1.50
+  bridge_port: 23
+  poll_interval: 60
+  mqtt:
+    host: 192.168.1.2
+    port: 1883
+    username: ""
+    password: ""
+schema:
+  bridge_host: str
+  bridge_port: int
+  poll_interval: int
+  mqtt:
+    host: str
+    port: int
+    username: str?
+    password: str?

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,21 @@
+#!/command/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+BRIDGE_HOST="$(bashio::config 'bridge_host')"
+BRIDGE_PORT="$(bashio::config 'bridge_port')"
+POLL_INTERVAL="$(bashio::config 'poll_interval')"
+MQTT_HOST="$(bashio::config 'mqtt.host')"
+MQTT_PORT="$(bashio::config 'mqtt.port')"
+MQTT_USER="$(bashio::config 'mqtt.username')"
+MQTT_PASS="$(bashio::config 'mqtt.password')"
+
+bashio::log.info "Starting Vevor EML3500 poller"
+exec python3 /app/poller.py \
+    --bridge-host "${BRIDGE_HOST}" \
+    --bridge-port "${BRIDGE_PORT}" \
+    --poll-interval "${POLL_INTERVAL}" \
+    --mqtt-host "${MQTT_HOST}" \
+    --mqtt-port "${MQTT_PORT}" \
+    --mqtt-username "${MQTT_USER}" \
+    --mqtt-password "${MQTT_PASS}"


### PR DESCRIPTION
## Summary
- scaffold add-on with config options for RS232 bridge and MQTT
- add Dockerfile targeting Home Assistant 2025.8 base image
- provide run script to launch Python poller

## Testing
- `yamllint config.yaml`
- `shellcheck run.sh`
- `hadolint Dockerfile`
- `bash -n run.sh`

