### PR TITLE
Add fault decoder and MQTT poller

### DIFF
--- a/fault_decoder.py
+++ b/fault_decoder.py
@@ -1,0 +1,63 @@
+"""Decode VEVOR EML3500 32-bit fault and warning registers.
+
+This module loads fault and warning code definitions from CSV files and
+provides helper functions to translate raw 32-bit register values into
+human readable descriptions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import csv
+from typing import Dict, List
+
+BASE_DIR = Path(__file__).resolve().parent
+FAULT_CODES_CSV = BASE_DIR / "docs" / "vevor_eml3500_24l_fault_codes.csv"
+WARNING_CODES_CSV = BASE_DIR / "docs" / "vevor_eml3500_24l_warning_codes.csv"
+
+
+def _load_codes(path: Path) -> Dict[int, str]:
+    """Load bit code mapping from a CSV file."""
+    codes: Dict[int, str] = {}
+    with path.open(newline="") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            bit_str = (row.get("Bit/Code") or "").strip()
+            if not bit_str.startswith("bit"):
+                continue
+            cleaned = bit_str.replace("bit", "").strip()
+            try:
+                bit_num = int(cleaned)
+            except ValueError:
+                continue
+            desc = (row.get("Explain") or "").strip()
+            codes[bit_num] = desc
+    return codes
+
+
+# Preload mappings
+FAULT_CODES = _load_codes(FAULT_CODES_CSV)
+WARNING_CODES = _load_codes(WARNING_CODES_CSV)
+
+
+def _decode(value: int, codes: Dict[int, str]) -> List[str]:
+    """Decode set bits in *value* using *codes* mapping."""
+    if not codes:
+        return []
+    base = min(codes)
+    decoded: List[str] = []
+    for bit, desc in codes.items():
+        mask = 1 << (bit - base)
+        if value & mask:
+            decoded.append(desc)
+    return decoded
+
+
+def decode_faults(value: int) -> List[str]:
+    """Return list of fault descriptions for a raw register value."""
+    return _decode(value, FAULT_CODES)
+
+
+def decode_warnings(value: int) -> List[str]:
+    """Return list of warning descriptions for a raw register value."""
+    return _decode(value, WARNING_CODES)

--- a/poller.py
+++ b/poller.py
@@ -1,0 +1,92 @@
+"""Poll VEVOR EML3500 registers and publish decoded statuses."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from typing import Optional
+
+import paho.mqtt.client as mqtt
+
+from modbus_client import ModbusRTUOverTCPClient
+from fault_decoder import decode_faults, decode_warnings
+
+
+async def poll_once(client: ModbusRTUOverTCPClient) -> tuple[str, str]:
+    fault_val = await client.read_register("Equipment fault code")
+    warn_val = await client.read_register(
+        "Obtain the warning code after shield processing"
+    )
+    faults = decode_faults(int(fault_val))
+    warnings = decode_warnings(int(warn_val))
+    fault_state = ", ".join(faults) if faults else "OK"
+    warning_state = ", ".join(warnings) if warnings else "OK"
+    return fault_state, warning_state
+
+
+def publish_discovery(
+    client: mqtt.Client, prefix: str = "vevor_eml3500"
+) -> None:
+    """Publish Home Assistant MQTT discovery config."""
+    sensors = {
+        "faults": "Faults",
+        "warnings": "Warnings",
+    }
+    for key, name in sensors.items():
+        topic = f"homeassistant/sensor/{prefix}_{key}/config"
+        payload = json.dumps(
+            {
+                "name": f"VEVOR {name}",
+                "state_topic": f"{prefix}/{key}",
+                "unique_id": f"{prefix}_{key}",
+            }
+        )
+        client.publish(topic, payload, retain=True)
+
+
+async def main(args: argparse.Namespace) -> None:
+    modbus = ModbusRTUOverTCPClient(
+        host=args.bridge_host,
+        port=args.bridge_port,
+        poll_interval=args.poll_interval,
+    )
+
+    mqtt_client: Optional[mqtt.Client] = None
+    if args.mqtt_host:
+        mqtt_client = mqtt.Client()
+        if args.mqtt_username:
+            mqtt_client.username_pw_set(
+                args.mqtt_username, args.mqtt_password or ""
+            )
+        mqtt_client.connect(args.mqtt_host, args.mqtt_port)
+        publish_discovery(mqtt_client)
+
+    try:
+        while True:
+            fault_state, warning_state = await poll_once(modbus)
+            if mqtt_client:
+                mqtt_client.publish(
+                    "vevor_eml3500/faults", fault_state, retain=True
+                )
+                mqtt_client.publish(
+                    "vevor_eml3500/warnings", warning_state, retain=True
+                )
+                mqtt_client.loop(0.1)
+            await asyncio.sleep(args.poll_interval)
+    finally:
+        await modbus.close()
+        if mqtt_client:
+            mqtt_client.disconnect()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="VEVOR EML3500 poller")
+    parser.add_argument("--bridge-host", required=True)
+    parser.add_argument("--bridge-port", type=int, default=23)
+    parser.add_argument("--poll-interval", type=int, default=60)
+    parser.add_argument("--mqtt-host", default="")
+    parser.add_argument("--mqtt-port", type=int, default=1883)
+    parser.add_argument("--mqtt-username", default="")
+    parser.add_argument("--mqtt-password", default="")
+    asyncio.run(main(parser.parse_args()))

--- a/tests/test_fault_decoder.py
+++ b/tests/test_fault_decoder.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fault_decoder import decode_faults, decode_warnings  # noqa: E402
+
+
+def test_decode_faults():
+    # bit3 -> Battery overvoltage
+    faults = decode_faults(1 << 2)
+    assert "Battery overvoltage" in faults
+
+
+def test_decode_warnings():
+    # bit 0 -> Mains supply zero-crossing loss
+    warnings = decode_warnings(1 << 0)
+    assert "Mains supply zero-crossing loss" in warnings


### PR DESCRIPTION
## Summary
- add helper to translate 32-bit fault and warning registers using CSV code tables
- poll fault and warning registers and publish decoded values as MQTT Home Assistant sensors
- test fault decoder bit translations

## Testing
- `flake8 fault_decoder.py poller.py tests/test_fault_decoder.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a31a6f7a4c83228b35a43708ee7a8a