### PR TITLE
Add poller unit test and ruff-based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pytest pytest-asyncio ruff pymodbus paho-mqtt
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest

--- a/modbus_client.py
+++ b/modbus_client.py
@@ -92,7 +92,9 @@ def load_register_definitions(csv_path: Path) -> Dict[str, RegisterDefinition]:
     return registers
 
 
-DEFAULT_REGISTER_CSV = Path(__file__).resolve().parent / "docs" / "vevor_eml3500_24l_registers.csv"
+DEFAULT_REGISTER_CSV = (
+    Path(__file__).resolve().parent / "docs" / "vevor_eml3500_24l_registers.csv"
+)
 
 
 class ModbusRTUOverTCPClient:
@@ -133,7 +135,7 @@ class ModbusRTUOverTCPClient:
         )
         if response.isError():
             raise RuntimeError(f"Read failed for {name}: {response}")
-        
+
         if reg.data_format == "ULong":
             value = (response.registers[0] << 16) + response.registers[1]
         elif reg.data_format == "UInt":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "W"]

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -1,13 +1,14 @@
 import sys
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import paho.mqtt.client as mqtt
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from poller import publish_discovery, publish_telemetry  # noqa: E402
+from poller import poll_once, publish_discovery, publish_telemetry  # noqa: E402
 
 
 def test_publish_discovery_includes_device_metadata():
@@ -28,4 +29,26 @@ def test_publish_telemetry_publishes_json():
         "test/telemetry",
         json.dumps({"faults": "OK", "warnings": "WARN"}),
         retain=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_poll_once_reads_registers_and_decodes():
+    client = AsyncMock()
+
+    async def fake_read(name: str):
+        if name == "Equipment fault code":
+            return 1 << 2  # Battery overvoltage
+        if name == "Obtain the warning code after shield processing":
+            return 1 << 0  # Mains supply zero-crossing loss
+        return 0
+
+    client.read_register.side_effect = fake_read
+    fault_state, warning_state = await poll_once(client)
+
+    assert "Battery overvoltage" in fault_state
+    assert "Mains supply zero-crossing loss" in warning_state
+    client.read_register.assert_any_call("Equipment fault code")
+    client.read_register.assert_any_call(
+        "Obtain the warning code after shield processing"
     )


### PR DESCRIPTION
## Summary
- extend poller tests with async Modbus polling check
- configure ruff linter via `pyproject.toml`
- add GitHub Actions workflow to run ruff and pytest

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a322041f3c8322a64724e7d706a635