### PR TITLE
Include app files and CSV docs in Docker image

### DIFF
--- a/vevor_eml3500_rs232_wifi/Dockerfile
+++ b/vevor_eml3500_rs232_wifi/Dockerfile
@@ -6,11 +6,16 @@ FROM ${BUILD_FROM}
 # hadolint ignore=DL3018
 RUN apk add --no-cache python3 py3-pip
 
+# Install required Python packages
+RUN pip install --no-cache-dir pymodbus paho-mqtt
+
 # Copy run script
-COPY run.sh /run.sh
+COPY vevor_eml3500_rs232_wifi/run.sh /run.sh
 RUN chmod +x /run.sh
 
-COPY . /app/vevor_eml3500_rs232_wifi
+# Copy application files and CSV documentation
+COPY vevor_eml3500_rs232_wifi /app/vevor_eml3500_rs232_wifi
+COPY docs/*.csv /app/docs/
 WORKDIR /app
 
 CMD [ "/run.sh" ]


### PR DESCRIPTION
## Summary
- copy add-on sources and documentation CSVs into `/app`
- install `pymodbus` and `paho-mqtt` during image build

## Testing
- `ruff check vevor_eml3500_rs232_wifi tests`
- `pytest`
- `docker build -t vevor-test -f vevor_eml3500_rs232_wifi/Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a32b1ebe8483228505e10e274de1ca