### PR TITLE
Fix Modbus register parameter handling

### DIFF
--- a/tests/test_modbus_client.py
+++ b/tests/test_modbus_client.py
@@ -1,10 +1,14 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from vevor_eml3500_24l_rs232_wifi.modbus_client import (
     DEFAULT_REGISTER_CSV,
+    RegisterDefinition,
+    ModbusRTUOverTCPClient,
     load_register_definitions,
 )
 
@@ -17,3 +21,38 @@ def test_load_registers():
     assert reg.count == 1
     assert reg.data_format == "Int"
     assert reg.scale == 0.1
+
+
+@pytest.mark.asyncio
+async def test_read_register_uses_keyword_count(monkeypatch):
+    client = ModbusRTUOverTCPClient("example.com")
+    client.registers = {
+        "test": RegisterDefinition(
+            name="test",
+            unit="",
+            data_format="UInt",
+            address=0,
+            count=1,
+            access="R",
+            remark="",
+        )
+    }
+
+    async def fake_connect():
+        return None
+
+    client.connect = fake_connect
+
+    async def fake_read(address, *, count=1, **kwargs):
+        class Resp:
+            def __init__(self):
+                self.registers = [42] * count
+
+            def isError(self):
+                return False
+
+        return Resp()
+
+    client.client.read_holding_registers = fake_read
+    value = await client.read_register("test")
+    assert value == 42

--- a/vevor_eml3500_24l_rs232_wifi/modbus_client.py
+++ b/vevor_eml3500_24l_rs232_wifi/modbus_client.py
@@ -148,7 +148,7 @@ class ModbusRTUOverTCPClient:
         await self.connect()
         kwargs = {self._slave_kwarg: self.unit} if self._slave_kwarg else {}
         response = await self.client.read_holding_registers(
-            reg.address, reg.count, **kwargs
+            reg.address, count=reg.count, **kwargs
         )
         if response.isError():
             raise RuntimeError(f"Read failed for {name}: {response}")
@@ -178,7 +178,7 @@ class ModbusRTUOverTCPClient:
                 await self.connect()
                 kwargs = {self._slave_kwarg: self.unit} if self._slave_kwarg else {}
                 response = await self.client.write_register(
-                    reg.address, raw, **kwargs
+                    reg.address, value=raw, **kwargs
                 )
                 if not response.isError():
                     return


### PR DESCRIPTION
## Summary
- send register count and value as keyword arguments for better pymodbus compatibility
- add regression test for read_register keyword usage

## Testing
- `ruff check vevor_eml3500_24l_rs232_wifi tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a34a7e6f248322af440c72ffb81dd1