### PR TITLE
Add battery and PV metrics with writable SOC limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Writable registers are updated by publishing to `{prefix}/set` with a JSON paylo
 | Slug | Description | Topic | Example payload |
 | ---- | ----------- | ----- | --------------- |
 | `warnings` | Clear warning code | `{prefix}/set` | `{"warnings": 0}` |
+| `battery_discharge_soc_limit` | Set battery discharge SOC limit | `{prefix}/set` | `{"battery_discharge_soc_limit": 20}` |
 
 ## Lovelace dashboard example
 
@@ -85,21 +86,30 @@ views:
           - sensor.vevor_mains_power
           - sensor.vevor_inverter_voltage
           - sensor.vevor_inverter_current
+          - sensor.vevor_battery_voltage
+          - sensor.vevor_battery_current
+          - sensor.vevor_battery_power
+          - sensor.vevor_battery_soc
+          - sensor.vevor_pv_voltage
+          - sensor.vevor_pv_current
+          - sensor.vevor_pv_power
           - sensor.vevor_faults
           - sensor.vevor_warnings
       - type: gauge
-        entity: sensor.vevor_mains_power
+        entity: sensor.vevor_battery_soc
         min: 0
-        max: 3500
-        name: Mains Power
+        max: 100
+        name: Battery SOC
       - type: entities
         title: Controls
         entities:
           - entity: number.vevor_warnings
             name: Clear Warnings
+          - entity: number.vevor_battery_discharge_soc_limit
+            name: Battery SOC Limit
 ```
 
-To enable the `number.vevor_warnings` entity, add the following to your `configuration.yaml`:
+To enable the `number.vevor_warnings` and `number.vevor_battery_discharge_soc_limit` entities, add the following to your `configuration.yaml`:
 
 ```yaml
 mqtt:
@@ -110,6 +120,13 @@ mqtt:
       command_template: '{"warnings": {{ value }} }'
       min: 0
       max: 0
+      step: 1
+    - unique_id: vevor_battery_discharge_soc_limit
+      name: VEVOR Battery SOC Limit
+      command_topic: "vevor_eml3500/set"
+      command_template: '{"battery_discharge_soc_limit": {{ value }} }'
+      min: 3
+      max: 30
       step: 1
 ```
 
@@ -124,6 +141,16 @@ When discovery is enabled, the following entities are created in Home Assistant:
 - `sensor.vevor_mains_power` – average mains power.
 - `sensor.vevor_inverter_voltage` – inverter output voltage.
 - `sensor.vevor_inverter_current` – inverter output current.
+- `sensor.vevor_battery_voltage` – battery voltage.
+- `sensor.vevor_battery_current` – battery current.
+- `sensor.vevor_battery_power` – battery power.
+- `sensor.vevor_battery_soc` – battery state of charge.
+- `sensor.vevor_pv_voltage` – PV input voltage.
+- `sensor.vevor_pv_current` – PV input current.
+- `sensor.vevor_pv_power` – PV input power.
+- `sensor.vevor_load_percent` – load percentage.
+- `sensor.vevor_dcdc_temperature` – DCDC temperature.
+- `sensor.vevor_inverter_temperature` – inverter temperature.
 
 ## RS232-to-WiFi bridge troubleshooting
 

--- a/vevor_eml3500_24l_rs232_wifi/poller.py
+++ b/vevor_eml3500_24l_rs232_wifi/poller.py
@@ -50,6 +50,71 @@ REGISTER_MAP = {
         "name": "Inverter Current",
         "unit": "A",
     },
+    "battery_voltage": {
+        "register": "Average battery voltage",
+        "name": "Battery Voltage",
+        "unit": "V",
+        "device_class": "voltage",
+    },
+    "battery_current": {
+        "register": "Average battery current",
+        "name": "Battery Current",
+        "unit": "A",
+        "device_class": "current",
+    },
+    "battery_power": {
+        "register": "Average battery power",
+        "name": "Battery Power",
+        "unit": "W",
+        "device_class": "power",
+    },
+    "battery_soc": {
+        "register": "Battery percentage",
+        "name": "Battery SOC",
+        "unit": "%",
+        "device_class": "battery",
+    },
+    "pv_voltage": {
+        "register": "Average PV voltage",
+        "name": "PV Voltage",
+        "unit": "V",
+        "device_class": "voltage",
+    },
+    "pv_current": {
+        "register": "Average PV current",
+        "name": "PV Current",
+        "unit": "A",
+        "device_class": "current",
+    },
+    "pv_power": {
+        "register": "Average PV power",
+        "name": "PV Power",
+        "unit": "W",
+        "device_class": "power",
+    },
+    "load_percent": {
+        "register": "Percent of load",
+        "name": "Load Percent",
+        "unit": "%",
+    },
+    "dcdc_temperature": {
+        "register": "DCDC temperature",
+        "name": "DCDC Temperature",
+        "unit": "°C",
+        "device_class": "temperature",
+    },
+    "inverter_temperature": {
+        "register": "Inverter temperature",
+        "name": "Inverter Temperature",
+        "unit": "°C",
+        "device_class": "temperature",
+    },
+    "battery_discharge_soc_limit": {
+        "register": "Battery discharge SOC protection value in off-grid mode",
+        "name": "Battery Discharge SOC Limit",
+        "unit": "%",
+        "writable": True,
+    },
 }
 
 WRITABLE_REGISTERS = {
@@ -93,6 +158,9 @@ def publish_discovery(
         }
         if unit := info.get("unit"):
             payload["unit_of_measurement"] = unit
+            payload["state_class"] = "measurement"
+        if device_class := info.get("device_class"):
+            payload["device_class"] = device_class
         client.publish(topic, json.dumps(payload), retain=True)
 
 


### PR DESCRIPTION
## Summary
- expose battery voltage, current, power and SOC from register map
- report PV voltage, current, power and other telemetry including load and temperatures
- allow setting battery discharge SOC limit via MQTT commands and document new entities

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3619d14e08322861a0c5896fff6cc