### PR TITLE
Expand VEVOR register coverage

### DIFF
--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -43,17 +43,53 @@ async def test_poll_once_reads_registers_and_decodes():
     client = AsyncMock()
 
     async def fake_read(name: str):
-        if name == "Equipment fault code":
-            return 1 << 2  # Battery overvoltage
-        if name == "Obtain the warning code after shield processing":
-            return 1 << 0  # Mains supply zero-crossing loss
-        return 0
+        mapping = {
+            "Equipment fault code": 1 << 2,  # Battery overvoltage
+            "Obtain the warning code after shield processing": 1 << 0,
+            "Working mode": 3,
+            "Inverter frequency": 50.0,
+            "Inverter power average": 1200.0,
+            "Inverter charging power": 500.0,
+            "Effective value of output voltage": 230.0,
+            "Effective value of output current": 5.0,
+            "Output frequency": 50.0,
+            "Output active power": 1000.0,
+            "Output apparent power": 1100.0,
+            "Average battery power": 200.0,
+            "Battery current filter average": -2.0,
+            "Average PV voltage": 150.0,
+            "Average PV current": 4.0,
+            "Average PV power": 600.0,
+            "Average PV charging power": 400.0,
+            "Average value of inverter charging current": 10.0,
+            "Average PV charging current": 6.0,
+            "Power flow status": 869,
+        }
+        return mapping.get(name, 0)
 
     client.read_register.side_effect = fake_read
     data = await poll_once(client)
 
     assert "Battery overvoltage" in data["faults"]
     assert "Mains supply zero-crossing loss" in data["warnings"]
+    assert data["working_mode"] == "Off-grid mode"
+    assert data["inverter_frequency"] == 50.0
+    assert data["inverter_power"] == 1200.0
+    assert data["inverter_charging_power"] == 500.0
+    assert data["output_voltage"] == 230.0
+    assert data["output_current"] == 5.0
+    assert data["output_frequency"] == 50.0
+    assert data["output_active_power"] == 1000.0
+    assert data["output_apparent_power"] == 1100.0
+    assert data["battery_current_filter_average"] == -2.0
+    assert data["pv_charging_power"] == 400.0
+    assert data["inverter_charging_current"] == 10.0
+    assert data["pv_charging_current"] == 6.0
+    assert "PV connected" in data["power_flow_status"]
+    assert "Mains connected" in data["power_flow_status"]
+    assert "Battery discharging" in data["power_flow_status"]
+    assert "Mains charging" in data["power_flow_status"]
+    assert "PV charging" in data["power_flow_status"]
     client.read_register.assert_any_call("Equipment fault code")
     client.read_register.assert_any_call(
         "Obtain the warning code after shield processing"

--- a/vevor_eml3500_24l_rs232_wifi/poller.py
+++ b/vevor_eml3500_24l_rs232_wifi/poller.py
@@ -11,6 +11,7 @@ import paho.mqtt.client as mqtt
 
 from .modbus_client import ModbusRTUOverTCPClient
 from .fault_decoder import decode_faults, decode_warnings
+from .status_decoder import decode_working_mode, decode_power_flow
 
 
 REGISTER_MAP = {
@@ -24,6 +25,11 @@ REGISTER_MAP = {
         "name": "Warnings",
         "decoder": decode_warnings,
         "writable": True,
+    },
+    "working_mode": {
+        "register": "Working mode",
+        "name": "Working Mode",
+        "decoder": decode_working_mode,
     },
     "mains_voltage": {
         "register": "Mains voltage effective value",
@@ -50,6 +56,52 @@ REGISTER_MAP = {
         "name": "Inverter Current",
         "unit": "A",
     },
+    "inverter_frequency": {
+        "register": "Inverter frequency",
+        "name": "Inverter Frequency",
+        "unit": "Hz",
+    },
+    "inverter_power": {
+        "register": "Inverter power average",
+        "name": "Inverter Power",
+        "unit": "W",
+        "device_class": "power",
+    },
+    "inverter_charging_power": {
+        "register": "Inverter charging power",
+        "name": "Inverter Charging Power",
+        "unit": "W",
+        "device_class": "power",
+    },
+    "output_voltage": {
+        "register": "Effective value of output voltage",
+        "name": "Output Voltage",
+        "unit": "V",
+        "device_class": "voltage",
+    },
+    "output_current": {
+        "register": "Effective value of output current",
+        "name": "Output Current",
+        "unit": "A",
+        "device_class": "current",
+    },
+    "output_frequency": {
+        "register": "Output frequency",
+        "name": "Output Frequency",
+        "unit": "Hz",
+    },
+    "output_active_power": {
+        "register": "Output active power",
+        "name": "Output Active Power",
+        "unit": "W",
+        "device_class": "power",
+    },
+    "output_apparent_power": {
+        "register": "Output apparent power",
+        "name": "Output Apparent Power",
+        "unit": "VA",
+        "device_class": "power",
+    },
     "battery_voltage": {
         "register": "Average battery voltage",
         "name": "Battery Voltage",
@@ -67,6 +119,12 @@ REGISTER_MAP = {
         "name": "Battery Power",
         "unit": "W",
         "device_class": "power",
+    },
+    "battery_current_filter_average": {
+        "register": "Battery current filter average",
+        "name": "Battery Current Filter Average",
+        "unit": "A",
+        "device_class": "current",
     },
     "battery_soc": {
         "register": "Battery percentage",
@@ -91,6 +149,29 @@ REGISTER_MAP = {
         "name": "PV Power",
         "unit": "W",
         "device_class": "power",
+    },
+    "pv_charging_power": {
+        "register": "Average PV charging power",
+        "name": "PV Charging Power",
+        "unit": "W",
+        "device_class": "power",
+    },
+    "inverter_charging_current": {
+        "register": "Average value of inverter charging current",
+        "name": "Inverter Charging Current",
+        "unit": "A",
+        "device_class": "current",
+    },
+    "pv_charging_current": {
+        "register": "Average PV charging current",
+        "name": "PV Charging Current",
+        "unit": "A",
+        "device_class": "current",
+    },
+    "power_flow_status": {
+        "register": "Power flow status",
+        "name": "Power Flow Status",
+        "decoder": decode_power_flow,
     },
     "load_percent": {
         "register": "Percent of load",
@@ -133,7 +214,10 @@ async def poll_once(client: ModbusRTUOverTCPClient) -> Dict[str, Any]:
         decoder = info.get("decoder")
         if decoder:
             decoded = decoder(int(value))
-            value = ", ".join(decoded) if decoded else "OK"
+            if isinstance(decoded, list):
+                value = ", ".join(decoded) if decoded else "OK"
+            else:
+                value = decoded
         results[slug] = value
     return results
 

--- a/vevor_eml3500_24l_rs232_wifi/status_decoder.py
+++ b/vevor_eml3500_24l_rs232_wifi/status_decoder.py
@@ -1,0 +1,54 @@
+"""Decode working mode and power flow status registers."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+WORKING_MODES = {
+    0: "Power on mode",
+    1: "Standby mode",
+    2: "Mains mode",
+    3: "Off-grid mode",
+    4: "Bypass mode",
+    5: "Charging mode",
+    6: "Failure mode",
+}
+
+
+def decode_working_mode(value: int) -> str:
+    """Return human readable working mode."""
+    return WORKING_MODES.get(value, f"Unknown ({value})")
+
+
+def decode_power_flow(value: int) -> List[str]:
+    """Decode bitfield from power flow status register."""
+    statuses: List[str] = []
+    pv = value & 0b11
+    if pv == 1:
+        statuses.append("PV connected")
+    mains = (value >> 2) & 0b11
+    if mains == 1:
+        statuses.append("Mains connected")
+    battery = (value >> 4) & 0b11
+    if battery == 1:
+        statuses.append("Battery charging")
+    elif battery == 2:
+        statuses.append("Battery discharging")
+    load = (value >> 6) & 0b11
+    if load == 1:
+        statuses.append("Load powered")
+    if value & (1 << 8):
+        statuses.append("Mains charging")
+    if value & (1 << 9):
+        statuses.append("PV charging")
+    if value & (1 << 10):
+        statuses.append("Battery icon off")
+    if value & (1 << 11):
+        statuses.append("PV icon off")
+    if value & (1 << 12):
+        statuses.append("Mains icon off")
+    if value & (1 << 13):
+        statuses.append("Load icon off")
+    return statuses
+


### PR DESCRIPTION
## Summary
- extend register map to include working mode, inverter/output metrics, PV charging data and power flow status
- add decoders for working mode and power flow bitfields
- exercise new registers in poller tests

## Testing
- `ruff check vevor_eml3500_24l_rs232_wifi/status_decoder.py vevor_eml3500_24l_rs232_wifi/poller.py tests/test_poller.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a36877f5d4832298be28b4a54cba1f