### PR TITLE
Add dashboard example and script documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ mqtt:
 
 The complete register table is available in [docs/registers.md](docs/registers.md).
 
-## MQTT register topics
+## Writable entities
 
 For each register, the poller publishes the latest value to `{prefix}/{slug}`. The default prefix is `vevor_eml3500`, so the mains voltage is exposed on `vevor_eml3500/mains_voltage`.
 
@@ -216,7 +216,24 @@ Writable registers are updated by publishing to `{prefix}/set` with a JSON paylo
 | `remote_switch` | Remote switch | `{"remote_switch": "remote power-on"}` |
 | `fault_info_query_index` | Fault info query index | `{"fault_info_query_index": 0}` |
 
-## Lovelace dashboard example
+## Script example
+
+The following Home Assistant script publishes a command to the inverter via MQTT:
+
+```yaml
+script:
+  vevor_clear_warnings:
+    alias: Clear VEVOR warnings
+    sequence:
+      - service: mqtt.publish
+        data:
+          topic: vevor_eml3500/set
+          payload: '{"warnings": 0}'
+```
+
+## Dashboard YAML
+
+A full dashboard example is available in [docs/dashboard_example.yaml](docs/dashboard_example.yaml).
 
 ```yaml
 views:

--- a/docs/dashboard_example.yaml
+++ b/docs/dashboard_example.yaml
@@ -1,0 +1,58 @@
+views:
+  - title: VEVOR Inverter
+    cards:
+      - type: entities
+        entities:
+          - sensor.vevor_working_mode
+          - sensor.vevor_mains_voltage
+          - sensor.vevor_mains_frequency
+          - sensor.vevor_mains_power
+          - sensor.vevor_inverter_voltage
+          - sensor.vevor_inverter_current
+          - sensor.vevor_inverter_frequency
+          - sensor.vevor_inverter_power
+          - sensor.vevor_inverter_charging_power
+          - sensor.vevor_output_voltage
+          - sensor.vevor_output_current
+          - sensor.vevor_output_frequency
+          - sensor.vevor_output_active_power
+          - sensor.vevor_output_apparent_power
+          - sensor.vevor_battery_voltage
+          - sensor.vevor_battery_current
+          - sensor.vevor_battery_power
+          - sensor.vevor_battery_current_filter_average
+          - sensor.vevor_battery_soc
+          - sensor.vevor_pv_voltage
+          - sensor.vevor_pv_current
+          - sensor.vevor_pv_power
+          - sensor.vevor_pv_charging_power
+          - sensor.vevor_inverter_charging_current
+          - sensor.vevor_pv_charging_current
+          - sensor.vevor_power_flow_status
+          - sensor.vevor_load_percent
+          - sensor.vevor_dcdc_temperature
+          - sensor.vevor_inverter_temperature
+          - sensor.vevor_faults
+          - sensor.vevor_warnings
+      - type: gauge
+        entity: sensor.vevor_battery_soc
+        min: 0
+        max: 100
+        name: Battery SOC
+      - type: entities
+        title: Controls
+        entities:
+          - entity: number.vevor_warnings
+            name: Clear Warnings
+          - entity: number.vevor_battery_discharge_soc_limit
+            name: Battery SOC Limit
+          - entity: select.vevor_output_mode
+            name: Output Mode
+          - entity: number.vevor_output_voltage_setting
+            name: Output Voltage
+          - entity: number.vevor_max_charge_current
+            name: Max Charge Current
+          - entity: select.vevor_battery_type
+            name: Battery Type
+          - entity: select.vevor_remote_switch
+            name: Remote Switch


### PR DESCRIPTION
## Summary
- document writable entities with a Home Assistant script example
- provide a copy-pasteable dashboard YAML example

## Testing
- no tests run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68a37aad4f948322a2b7c22dea45da19