### PR TITLE
Add MQTT configuration example

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,0 +1,18 @@
+mqtt:
+  broker: "mqtt.example.com"
+  username: "your_username"
+  password: "your_password"
+  discovery: true
+  discovery_prefix: homeassistant
+  number:
+    - name: "Vevor Setting"
+      command_topic: "vevor_eml3500_24l_vevor/set"
+      min: 0
+      max: 100
+      step: 1
+  select:
+    - name: "Vevor Mode"
+      command_topic: "vevor_eml3500_24l_vevor/set"
+      options:
+        - option1
+        - option2


### PR DESCRIPTION
## Summary
- add Home Assistant `mqtt` config example with `number` and `select` entities targeting `vevor_eml3500_24l_vevor/set`

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a39543d148832289d2da5869b888cf