### PR TITLE
Poll before MQTT discovery and republish state after commands

### DIFF
--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -135,3 +135,20 @@ async def test_handle_command_individual_topic():
     modbus = AsyncMock()
     await handle_command(modbus, "parallel", slug="output_mode")
     modbus.write_register.assert_awaited_once_with("Output mode", 1.0)
+
+
+@pytest.mark.asyncio
+async def test_handle_command_publishes_state():
+    modbus = AsyncMock()
+    mqtt_client = MagicMock(spec=mqtt.Client)
+    modbus.read_register.return_value = 1
+    await handle_command(
+        modbus,
+        "parallel",
+        slug="output_mode",
+        mqtt_client=mqtt_client,
+        prefix="test",
+    )
+    mqtt_client.publish.assert_called_once_with(
+        "test/output_mode", "parallel", retain=True
+    )


### PR DESCRIPTION
## Summary
- poll inverter once before publishing MQTT discovery to provide initial state
- publish updated register state immediately after each handled command
- test handle_command publishes updated MQTT state

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e46db11c83229bf83197e86194e7