### PR TITLE
Add timeout and retry to Modbus register reads

### DIFF
--- a/vevor_eml3500_24l_rs232_wifi/config.yaml
+++ b/vevor_eml3500_24l_rs232_wifi/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: VEVOR EML3500-24L RS232 Wi-Fi bridge
-version: "0.1.0"
+version: "0.1.1"
 slug: vevor_eml3500_24l_rs232_wifi
 description: Polls VEVOR EML3500-24L via RS232/WiFi bridge and publishes to MQTT.
 arch:


### PR DESCRIPTION
## Summary
- retry reading Modbus registers on timeout with configurable timeout
- log register name and retry count
- bump add-on version to 0.1.1

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa25b62f248322887b2c8577a3b1fc