### PR TITLE
Handle read errors during polling

### DIFF
--- a/vevor_eml3500_24l_rs232_wifi/config.yaml
+++ b/vevor_eml3500_24l_rs232_wifi/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: VEVOR EML3500-24L RS232 Wi-Fi bridge
-version: "0.1.2"
+version: "0.1.3"
 slug: vevor_eml3500_24l_rs232_wifi
 description: Polls VEVOR EML3500-24L via RS232/WiFi bridge and publishes to MQTT.
 arch:


### PR DESCRIPTION
## Summary
- wrap each Modbus register read in a try/except and log stale data on failure
- bump add-on version to 0.1.3
- test coverage for error handling in polling

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2c5eca108322a32f89567be40257