### PR TITLE
Use thread-safe MQTT command handling

### DIFF
--- a/vevor_eml3500_24l_rs232_wifi/config.yaml
+++ b/vevor_eml3500_24l_rs232_wifi/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: VEVOR EML3500-24L RS232 Wi-Fi bridge
-version: "0.1.3"
+version: "0.1.4"
 slug: vevor_eml3500_24l_rs232_wifi
 description: Polls VEVOR EML3500-24L via RS232/WiFi bridge and publishes to MQTT.
 arch:


### PR DESCRIPTION
## Summary
- run MQTT command handlers on the main event loop using asyncio.run_coroutine_threadsafe
- retrieve running event loop in poller startup
- bump add-on version to 0.1.4

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aae9d03d148322a110b362e1fe3a79