### PR TITLE
Improve error handling for register writes

### DIFF
--- a/vevor_eml3500_24l_rs232_wifi/config.yaml
+++ b/vevor_eml3500_24l_rs232_wifi/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: VEVOR EML3500-24L RS232 Wi-Fi bridge
-version: "0.1.4"
+version: "0.1.5"
 slug: vevor_eml3500_24l_rs232_wifi
 description: Polls VEVOR EML3500-24L via RS232/WiFi bridge and publishes to MQTT.
 arch:


### PR DESCRIPTION
## Summary
- warn when an unknown writable register is requested and publish an MQTT error topic
- log and publish failures for register write operations
- bump addon version to 0.1.5

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aaefd067c0832280021fab80c3899d