### PR TITLE
Add MQTT availability reporting

### DIFF
--- a/vevor_eml3500_24l_rs232_wifi/config.yaml
+++ b/vevor_eml3500_24l_rs232_wifi/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: VEVOR EML3500-24L RS232 Wi-Fi bridge
-version: "0.1.5"
+version: "0.1.6"
 slug: vevor_eml3500_24l_rs232_wifi
 description: Polls VEVOR EML3500-24L via RS232/WiFi bridge and publishes to MQTT.
 arch:

--- a/vevor_eml3500_24l_rs232_wifi/poller.py
+++ b/vevor_eml3500_24l_rs232_wifi/poller.py
@@ -578,6 +578,9 @@ def publish_discovery(
             "state_topic": f"{prefix}/{slug}",
             "unique_id": f"{prefix}_{slug}",
             "device": device_info,
+            "availability_topic": f"{prefix}/availability",
+            "payload_available": "online",
+            "payload_not_available": "offline",
         }
         if writable:
             command_topic = f"{prefix}/{slug}/set"
@@ -720,6 +723,9 @@ async def main(args: argparse.Namespace) -> None:
                 args.mqtt_host, args.mqtt_port, keepalive=args.mqtt_keepalive
             )
             mqtt_client.loop_start()
+            mqtt_client.publish(
+                f"{prefix}/availability", "online", retain=True
+            )
         except OSError as err:  # pragma: no cover - network error
             print(f"MQTT connect failed: {err}")
             mqtt_client = None
@@ -781,6 +787,9 @@ async def main(args: argparse.Namespace) -> None:
                         args.mqtt_host, args.mqtt_port, keepalive=args.mqtt_keepalive
                     )
                     mqtt_client.loop_start()
+                    mqtt_client.publish(
+                        f"{prefix}/availability", "online", retain=True
+                    )
                 except OSError as err:  # pragma: no cover - network error
                     print(f"MQTT reconnect failed: {err}")
                     mqtt_client = None
@@ -812,6 +821,9 @@ async def main(args: argparse.Namespace) -> None:
     finally:
         await modbus.close()
         if mqtt_client:
+            mqtt_client.publish(
+                f"{prefix}/availability", "offline", retain=True
+            )
             mqtt_client.loop_stop()
             mqtt_client.disconnect()
 


### PR DESCRIPTION
## Summary
- include MQTT availability fields in discovery payloads
- publish online/offline status when connecting or shutting down
- bump add-on version to 0.1.6

## Testing
- `ruff check vevor_eml3500_24l_rs232_wifi tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5be37b76483229f2142cae34f5137