### PR TITLE
Handle missing power readings safely

### DIFF
--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -333,3 +333,14 @@ def test_energy_state_multiple_poll_cycles(tmp_path, monkeypatch):
     assert reloaded["grid_import_energy"] == pytest.approx(1.5 / 60, rel=1e-3)
     assert reloaded["pv_energy"] == pytest.approx(0.75 / 60, rel=1e-3)
     assert reloaded["battery_charge_energy"] == pytest.approx(0.3 / 60, rel=1e-3)
+
+
+def test_update_energy_state_handles_none_and_invalid_values():
+    state = {slug: 1.0 for slug in poller.ENERGY_SENSORS}
+    initial = state.copy()
+    data = {"mains_power": None, "pv_power": "invalid", "battery_power": None}
+
+    update_energy_state(data, state, 60)
+
+    for slug, value in state.items():
+        assert value == pytest.approx(initial[slug])

--- a/vevor_eml3500_24l_rs232_wifi/config.yaml
+++ b/vevor_eml3500_24l_rs232_wifi/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: VEVOR EML3500-24L RS232 Wi-Fi bridge
-version: "0.1.7"
+version: "0.1.8"
 slug: vevor_eml3500_24l_rs232_wifi
 description: Polls VEVOR EML3500-24L via RS232/WiFi bridge and publishes to MQTT.
 arch:

--- a/vevor_eml3500_24l_rs232_wifi/poller.py
+++ b/vevor_eml3500_24l_rs232_wifi/poller.py
@@ -492,6 +492,17 @@ ALL_SENSORS = {**REGISTER_MAP, **ENERGY_SENSORS}
 ENERGY_STATE_FILE = Path("energy_state.json")
 
 
+def _safe_float(value: Any) -> float:
+    """Convert value to float, returning 0.0 if conversion fails."""
+
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def load_energy_state() -> Dict[str, float]:
     """Load persistent energy values from disk."""
     if ENERGY_STATE_FILE.exists():
@@ -519,17 +530,17 @@ def update_energy_state(
     """Integrate power readings over interval to update energies."""
     hours = interval / 3600.0
 
-    mains_power = float(data.get("mains_power", 0.0))
+    mains_power = _safe_float(data.get("mains_power", 0.0))
     if mains_power > 0:
         state["grid_import_energy"] += mains_power / 1000.0 * hours
     elif mains_power < 0:
         state["grid_export_energy"] += -mains_power / 1000.0 * hours
 
-    pv_power = float(data.get("pv_power", 0.0))
+    pv_power = _safe_float(data.get("pv_power", 0.0))
     if pv_power > 0:
         state["pv_energy"] += pv_power / 1000.0 * hours
 
-    battery_power = float(data.get("battery_power", 0.0))
+    battery_power = _safe_float(data.get("battery_power", 0.0))
     if battery_power > 0:
         state["battery_discharge_energy"] += battery_power / 1000.0 * hours
     elif battery_power < 0:


### PR DESCRIPTION
## Summary
- add a helper to safely convert power readings to floats before energy accumulation
- ensure energy state updates ignore None or invalid power values via new tests
- bump the add-on version to 0.1.8

## Testing
- pytest
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68d6a7dc01bc8322963bcc86e3d1b669