### PR TITLE
Add daily energy sensors and persistence handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,50 +340,27 @@ When discovery is enabled, the following entities are created in Home Assistant:
 
 ## Energy dashboard
 
-The add-on exposes several power sensors that can feed Home Assistant's Energy dashboard:
+The add-on now publishes long-term energy counters alongside the instantaneous power sensors. Use the following sensors as inputs to Home Assistant's Energy dashboard:
 
-- `sensor.vevor_mains_power` – power imported from the grid
-- `sensor.vevor_pv_power` – photovoltaic (PV) production
-- `sensor.vevor_output_active_power` – load consumption
-- `sensor.vevor_battery_power` – battery charge (negative) / discharge (positive)
+- `sensor.vevor_grid_import_energy` / `sensor.vevor_grid_export_energy` – lifetime grid import and export totals.
+- `sensor.vevor_pv_energy` – lifetime photovoltaic production.
+- `sensor.vevor_battery_charge_energy` / `sensor.vevor_battery_discharge_energy` – cumulative battery charge and discharge.
 
-Convert these to cumulative energy sensors using the Riemann sum integration platform:
+For convenience, the add-on also exposes daily-resetting counters (`*_today`) that you can visualise in dashboards:
 
-```yaml
-sensor:
-  - platform: integration
-    source: sensor.vevor_pv_power
-    name: vevor_pv_energy
-    unit_prefix: k
-    round: 2
+- `sensor.vevor_grid_import_energy_today`
+- `sensor.vevor_grid_export_energy_today`
+- `sensor.vevor_pv_energy_today`
+- `sensor.vevor_battery_charge_energy_today`
+- `sensor.vevor_battery_discharge_energy_today`
 
-  - platform: integration
-    source: sensor.vevor_mains_power
-    name: vevor_grid_energy
-    unit_prefix: k
-    round: 2
-
-  - platform: integration
-    source: sensor.vevor_output_active_power
-    name: vevor_load_energy
-    unit_prefix: k
-    round: 2
-
-  - platform: integration
-    source: sensor.vevor_battery_power
-    name: vevor_battery_energy
-    unit_prefix: k
-    round: 2
-```
-
-To link these sensors in the Energy dashboard:
+To link the lifetime sensors in the Energy dashboard:
 
 1. In Home Assistant, open **Settings → Dashboards → Energy**.
-2. Under **Electricity grid**, select `sensor.vevor_grid_energy` for consumption (and return if applicable).
+2. Under **Electricity grid**, select `sensor.vevor_grid_import_energy` for consumption and `sensor.vevor_grid_export_energy` for return (if applicable).
 3. Under **Solar production**, choose `sensor.vevor_pv_energy`.
-4. Under **Home batteries**, pick `sensor.vevor_battery_energy`.
-5. Under **Individual devices**, add `sensor.vevor_load_energy` to track load usage.
-6. Save the dashboard and allow data to accumulate.
+4. Under **Home batteries**, pick `sensor.vevor_battery_charge_energy` for charging and `sensor.vevor_battery_discharge_energy` for discharging.
+5. Save the dashboard and allow data to accumulate.
 
 ## RS232-to-WiFi bridge troubleshooting
 

--- a/docs/dashboard_example.yaml
+++ b/docs/dashboard_example.yaml
@@ -29,6 +29,16 @@ views:
           - sensor.vevor_inverter_charging_current
           - sensor.vevor_pv_charging_current
           - sensor.vevor_power_flow_status
+          - sensor.vevor_grid_import_energy
+          - sensor.vevor_grid_export_energy
+          - sensor.vevor_pv_energy
+          - sensor.vevor_battery_charge_energy
+          - sensor.vevor_battery_discharge_energy
+          - sensor.vevor_grid_import_energy_today
+          - sensor.vevor_grid_export_energy_today
+          - sensor.vevor_pv_energy_today
+          - sensor.vevor_battery_charge_energy_today
+          - sensor.vevor_battery_discharge_energy_today
           - sensor.vevor_load_percent
           - sensor.vevor_dcdc_temperature
           - sensor.vevor_inverter_temperature

--- a/vevor_eml3500_24l_rs232_wifi/config.yaml
+++ b/vevor_eml3500_24l_rs232_wifi/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: VEVOR EML3500-24L RS232 Wi-Fi bridge
-version: "0.1.8"
+version: "0.1.9"
 slug: vevor_eml3500_24l_rs232_wifi
 description: Polls VEVOR EML3500-24L via RS232/WiFi bridge and publishes to MQTT.
 arch:


### PR DESCRIPTION
## Summary
- extend the MQTT energy sensor set with new daily counters and persist them alongside the last processed date
- reset daily energy values when the local day changes while continuing to accumulate lifetime totals
- document the new sensors, update the sample dashboard, and bump the add-on version

## Testing
- ruff check
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6b7f4eb548322b0232f10fa948f5e